### PR TITLE
APK compatible version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray-geodata
-PKG_VERSION:=$(shell date "+%Y-%m-%d")
+PKG_VERSION:=$(shell date "+%Y.%m.%d")
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)


### PR DESCRIPTION
Change PKG_VERSION from format "%Y-%m-%d" to "%Y.%m.%d" for APK compatible version schema, according to https://github.com/openwrt/openwrt/pull/14918 . Otherwise compilation will fail on current OpenWRT snapshot due to invalid package version error.

```
if [ -z "$(ls -A /tmp/openwrt/build_dir/target-aarch64_cortex-a53_musl/v2ray-geodata/ipkg-all/v2ray-geoip/CONTROL 2>/dev/null)" ]; then rm -rf /tmp/openwrt/build_dir/target-aarch64_cortex-a53_musl/v2ray-geodata/ipkg-all/v2ray-geoip/CONTROL; else echo "CONTROL dire
ctory /tmp/openwrt/build_dir/target-aarch64_cortex-a53_musl/v2ray-geodata/ipkg-all/v2ray-geoip/CONTROL is not empty! This is not right and should be checked!" >&2; exit 1; fi                                                                                          
/tmp/openwrt/staging_dir/host/bin/fakeroot /tmp/openwrt/staging_dir/host/bin/apk mkpkg --info "name:v2ray-geoip" --info "version:2025-01-25-r1" --info "description:GeoIP List for V2Ray" --info "arch:noarch" --info "license:CC-BY-SA-4.0" --info "origin:feeds/base/v
2ray-geodata" --info "url:https://www.v2fly.org" --info "maintainer:sbwml <admin@cooluc.com>" --info "provides:"  --script "post-install:/tmp/openwrt/build_dir/target-aarch64_cortex-a53_musl/v2ray-geodata/apk-all/v2ray-geoip/post-install" --script "pre-deinstall:/
tmp/openwrt/build_dir/target-aarch64_cortex-a53_musl/v2ray-geodata/apk-all/v2ray-geoip/pre-deinstall" --info "depends:libc" --files "/tmp/openwrt/build_dir/target-aarch64_cortex-a53_musl/v2ray-geodata/ipkg-all/v2ray-geoip" --output "/tmp/openwrt/bin/packages/aarch
64_cortex-a53/base/v2ray-geoip-2025-01-25-r1.apk" --sign "/tmp/openwrt/private-key.pem"                                                                                                                                                                                 
ERROR: info field 'version' has invalid value: package version is invalid                                                                                                                                                                                               
ERROR: failed to create package: /tmp/openwrt/bin/packages/aarch64_cortex-a53/base/v2ray-geoip-2025-01-25-r1.apk: package version is invalid                                                                                                                            
make[3]: *** [Makefile:92: /tmp/openwrt/bin/packages/aarch64_cortex-a53/base/v2ray-geoip-2025-01-25-r1.apk] Error 99                
```